### PR TITLE
Added MarshalJSON for ObjectID

### DIFF
--- a/bson/objectid/objectid.go
+++ b/bson/objectid/objectid.go
@@ -77,6 +77,11 @@ func FromHex(s string) (ObjectID, error) {
 	return oid, nil
 }
 
+// MarshalJSON returns the ObjectID as a string
+func (id *ObjectID) MarshalJSON() ([]byte, error) {
+	return json.Marshal(id.Hex())
+}
+
 // UnmarshalJSON populates the byte slice with the ObjectID. If the byte slice is 64 bytes long, it
 // will be populated with the hex representation of the ObjectID. If the byte slice is twelve bytes
 // long, it will be populated with the BSON representation of the ObjectID. Otherwise, it will

--- a/bson/objectid/objectid.go
+++ b/bson/objectid/objectid.go
@@ -78,7 +78,7 @@ func FromHex(s string) (ObjectID, error) {
 }
 
 // MarshalJSON returns the ObjectID as a string
-func (id *ObjectID) MarshalJSON() ([]byte, error) {
+func (id ObjectID) MarshalJSON() ([]byte, error) {
 	return json.Marshal(id.Hex())
 }
 


### PR DESCRIPTION
Currently, if we sent data to client, client gets data and type of id is array.
MarshalJSON encodes the ObjectID in to string.